### PR TITLE
Add altitude

### DIFF
--- a/Adafruit_DPS310.cpp
+++ b/Adafruit_DPS310.cpp
@@ -255,6 +255,26 @@ bool Adafruit_DPS310::pressureAvailable(void) {
 
 /**************************************************************************/
 /*!
+ * @brief Calculates the approximate altitude using barometric pressure and the
+ * supplied sea level hPa as a reference.
+ * @param seaLevelhPa
+ *        The current hPa at sea level.
+ * @return The approximate altitude above sea level in meters.
+ */
+/**************************************************************************/
+float Adafruit_DPS310::readAltitude(float seaLevelhPa) {
+
+  float altitude;
+
+  _read();
+
+  altitude = 44330 * (1.0 - pow((_pressure / 100) / seaLevelhPa, 0.1903));
+
+  return altitude;
+}
+
+/**************************************************************************/
+/*!
     @brief  Set the operational mode of the sensor (continuous or one-shot)
     @param mode can be DPS310_IDLE, one shot: DPS310_ONE_PRESSURE or
    DPS310_ONE_TEMPERATURE, continuous: DPS310_CONT_PRESSURE, DPS310_CONT_TEMP,

--- a/Adafruit_DPS310.h
+++ b/Adafruit_DPS310.h
@@ -120,6 +120,8 @@ public:
   bool pressureAvailable(void);
   bool temperatureAvailable(void);
 
+  float readAltitude(float seaLevelhPa = 1013.25);
+
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getPressureSensor(void);
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit DPS310
-version=1.0.5
+version=1.1.0
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the Adafruit DPS310 barometric pressure sensor.


### PR DESCRIPTION
For #3. Add a `readAltitude()` function. Naming aligns with similar function in BMP280 lib.

**NOTE** This works, but seems possibly a little confusing to have some parameters accessed via the `sensor_event_t` struct and some parameters accessed via `readFoo()` functions?

Tested with an Itsy M0:
```cpp
#include <Adafruit_DPS310.h>

Adafruit_DPS310 dps;

void setup() {
  Serial.begin(9600);
  while (!Serial) delay(10);

  Serial.println("DPS310 Altitude Test");
  if (! dps.begin_I2C()) {
    Serial.println("Failed to find DPS");
    while (1) yield();
  }
  Serial.println("DPS OK!");

  dps.configurePressure(DPS310_64HZ, DPS310_64SAMPLES);
  dps.configureTemperature(DPS310_64HZ, DPS310_64SAMPLES);
}

void loop() {  
  while (!dps.temperatureAvailable() || !dps.pressureAvailable()) {
    return; // wait until there's something to read
  }

  float altitude = dps.readAltitude();

  Serial.print("Altitude = ");
  Serial.print(altitude);
  Serial.println(" m");

  delay(100);
}
```

![Screenshot from 2020-08-27 09-47-51](https://user-images.githubusercontent.com/8755041/91471101-72d4e400-e84a-11ea-895b-c8ed61efd053.png)
