### PR TITLE
Fixing pressure being assigned to temperature.

### DIFF
--- a/Adafruit_DPS310.cpp
+++ b/Adafruit_DPS310.cpp
@@ -441,7 +441,7 @@ bool Adafruit_DPS310::getEvents(sensors_event_t *temp_event,
     pressure_event->sensor_id = _sensorID;
     pressure_event->type = SENSOR_TYPE_PRESSURE;
     pressure_event->timestamp = millis();
-    pressure_event->temperature = _pressure / 100;
+    pressure_event->pressure = _pressure / 100;
   }
 
   return true;


### PR DESCRIPTION
This 'bug' wasn't presenting as a bug because both temp and pressure
were union floats within the sensor_event_t 'unified sensor library'. Regardless, the code is wrong.